### PR TITLE
Initialize paver before the image is fully loaded

### DIFF
--- a/jquery.paver.js
+++ b/jquery.paver.js
@@ -106,8 +106,16 @@
 					_fun.getCenter(this);
 
 					// Wait for panorama to load
-					var img = new Image();
-					img.onload = function() {
+					paver.$p.on('load', checkReadiness);
+					var timer = setInterval(checkReadiness, 50);
+					function checkReadiness () {
+						if (paver.$p[0].naturalWidth) {
+							paver.$p.off('load', checkReadiness);
+							clearInterval(timer);
+							init();
+						}
+					}
+					function init() {
 						// Fire image loaded event
 						paver.$t.trigger('imageLoadDone.paver');
 
@@ -159,10 +167,7 @@
 						paver.$t.on('pan.paver', function(e, ratio) {
 							paver.pan(ratio);
 						});
-							
-					};
-					img.src = paver.$p.attr('src');
-
+					}
 				}
 			},
 			fallback: function() {

--- a/jquery.paver.js
+++ b/jquery.paver.js
@@ -105,17 +105,14 @@
 					_fun.getContainerDimensions(this);
 					_fun.getCenter(this);
 
-					// Wait for panorama to load
-					paver.$p.on('load', checkReadiness);
-					var timer = setInterval(checkReadiness, 50);
-					function checkReadiness () {
+					var checkReadiness = function () {
 						if (paver.$p[0].naturalWidth) {
 							paver.$p.off('load', checkReadiness);
 							clearInterval(timer);
 							init();
 						}
 					}
-					function init() {
+					var init = function() {
 						// Fire image loaded event
 						paver.$t.trigger('imageLoadDone.paver');
 
@@ -168,6 +165,10 @@
 							paver.pan(ratio);
 						});
 					}
+					
+					// Wait for panorama to load
+					paver.$p.on('load', checkReadiness);
+					var timer = setInterval(checkReadiness, 50);
 				}
 			},
 			fallback: function() {


### PR DESCRIPTION
`naturalWidth` and `naturalHeight` are available as soon as the header of the image is loaded, which for panoramas could be available several seconds before the image is fully loaded.

To verify this I used a lightweight polling function and still kept a listener on the full `load` just in case that happens between each poll, which could save up to 50ms (!!!)
